### PR TITLE
Use ::std::string::String for return type of create_function

### DIFF
--- a/src/build_tools/genmsg.rs
+++ b/src/build_tools/genmsg.rs
@@ -91,7 +91,7 @@ pub fn depend_on_messages(folders: &[&str], messages: &[&str]) -> Result<String>
 
 fn create_function(name: &str, value: &str) -> String {
     format!(r#"
-            fn {}() -> String {{
+            fn {}() -> ::std::string::String {{
                 {:?}.into()
             }}"#,
             name,


### PR DESCRIPTION
If the msg name is String, for example `std_msgs/String`,
`String` is considered as the message in my environment.