### PR TITLE
do not emit error when rospy.wait_for_service() called

### DIFF
--- a/rosrust/src/tcpros/service.rs
+++ b/rosrust/src/tcpros/service.rs
@@ -82,10 +82,13 @@ where
     for mut stream in connections {
         // Service request starts by exchanging connection headers
         if let Err(err) = exchange_headers::<T, _>(&mut stream, service, node_name) {
-            error!(
-                "Failed to exchange headers for service '{}': {}",
-                service, err
-            );
+            // Cconnection can be closed when a client checks for a service.
+            if !err.is_closed_connection() {
+                error!(
+                    "Failed to exchange headers for service '{}': {}",
+                    service, err
+                );
+            }
             continue;
         }
 

--- a/rosrust/src/tcpros/service.rs
+++ b/rosrust/src/tcpros/service.rs
@@ -82,7 +82,7 @@ where
     for mut stream in connections {
         // Service request starts by exchanging connection headers
         if let Err(err) = exchange_headers::<T, _>(&mut stream, service, node_name) {
-            // Cconnection can be closed when a client checks for a service.
+            // Connection can be closed when a client checks for a service.
             if !err.is_closed_connection() {
                 error!(
                     "Failed to exchange headers for service '{}': {}",


### PR DESCRIPTION
The following program previously would cause an error message to be
logged:

```
import rospy

rospy.init_node('test_wait_for_service')
rospy.wait_for_service('/add_two_ints')
```

This commit stops such an error from being logged.

This fixes #51.