### PR TITLE
Fixed publishing and subscribing with other ros client libraries

### DIFF
--- a/rosrust/src/rosmsg.rs
+++ b/rosrust/src/rosmsg.rs
@@ -25,7 +25,10 @@ pub trait RosMsg: std::marker::Sized {
 
     #[inline]
     fn decode_slice(bytes: &[u8]) -> io::Result<Self> {
-        Self::decode(&mut io::Cursor::new(bytes))
+        let mut reader = io::Cursor::new(bytes);
+        // skip the first 4 bytes that contain the message length
+        reader.set_position(4);
+        Self::decode(&mut reader)
     }
 }
 

--- a/rosrust/src/rosmsg.rs
+++ b/rosrust/src/rosmsg.rs
@@ -253,10 +253,10 @@ impl RosMsg for Duration {
 
 #[inline]
 fn read_data_size<R: io::Read>(r: R) -> io::Result<u32> {
-    u32::decode(r).map(|v| v - 4)
+    u32::decode(r)
 }
 
 #[inline]
 fn write_data_size<W: io::Write>(value: u32, w: W) -> io::Result<()> {
-    (value + 4).encode(w)
+    value.encode(w)
 }


### PR DESCRIPTION
The message body length field was missing / did not get parsed correctly resulting in publishing / subscribing working between rosrust publishers and subscribers, but not working with publishers/subscribers written with other client libraries.

If I can find some time I'll ake a look at writing some simple integration tests to prevent those kinds of bugs in the future (see #45  ).