### PR TITLE
Adds reserved keyword handling.

### DIFF
--- a/rosrust_codegen/src/msg.rs
+++ b/rosrust_codegen/src/msg.rs
@@ -166,6 +166,60 @@ impl Msg {
     }
 }
 
+static RESERVED_KEYWORDS: [&'static str; 52] = [
+    "as",
+    "break",
+    "const",
+    "continue",
+    "crate",
+    "else",
+    "enum",
+    "extern",
+    "false",
+    "fn",
+    "for",
+    "if",
+    "impl",
+    "in",
+    "let",
+    "loop",
+    "match",
+    "mod",
+    "move",
+    "mut",
+    "pub",
+    "ref",
+    "return",
+    "Self",
+    "self",
+    "static",
+    "struct",
+    "super",
+    "trait",
+    "true",
+    "type",
+    "unsafe",
+    "use",
+    "where",
+    "while",
+    "abstract",
+    "alignof",
+    "become",
+    "box",
+    "do",
+    "final",
+    "macro",
+    "offsetof",
+    "override",
+    "priv",
+    "proc",
+    "pure",
+    "sizeof",
+    "typeof",
+    "unsized",
+    "virtual",
+    "yield",
+];
 static IGNORE_WHITESPACE: &'static str = r"\s*";
 static ANY_WHITESPACE: &'static str = r"\s+";
 static FIELD_TYPE: &'static str = r"([a-zA-Z0-9_/]+)";
@@ -505,10 +559,16 @@ impl FieldInfo {
     }
 
     fn new(datatype: &str, name: &str, case: FieldCase) -> Result<FieldInfo> {
+        let field_name = name.to_owned() +
+            if RESERVED_KEYWORDS.iter().any(|n| *n == name) {
+                "_"
+            } else {
+                ""
+            };
         Ok(FieldInfo {
             datatype: parse_datatype(datatype)
                 .ok_or_else(|| format!("Unsupported datatype: {}", datatype))?,
-            name: name.to_owned(),
+            name: field_name,
             case,
         })
     }

--- a/rosrust_codegen/src/msg_examples/visualization_msgs/msg/ImageMarker.msg
+++ b/rosrust_codegen/src/msg_examples/visualization_msgs/msg/ImageMarker.msg
@@ -1,0 +1,24 @@
+uint8 CIRCLE=0
+uint8 LINE_STRIP=1
+uint8 LINE_LIST=2
+uint8 POLYGON=3
+uint8 POINTS=4
+
+uint8 ADD=0
+uint8 REMOVE=1
+
+Header header
+string ns	# namespace, used with id to form a unique id
+int32 id          	# unique id within the namespace
+int32 type        	# CIRCLE/LINE_STRIP/etc.
+int32 action      	# ADD/REMOVE
+geometry_msgs/Point position # 2D, in pixel-coords
+float32 scale	 	# the diameter for a circle, etc.
+std_msgs/ColorRGBA outline_color
+uint8 filled	# whether to fill in the shape with color
+std_msgs/ColorRGBA fill_color # color [0.0-1.0]
+duration lifetime       # How long the object should last before being automatically deleted.  0 means forever
+
+
+geometry_msgs/Point[] points # used for LINE_STRIP/LINE_LIST/POINTS/etc., 2D in pixel coords
+std_msgs/ColorRGBA[] outline_colors # a color for each line, point, etc.


### PR DESCRIPTION
Messages such as [visualization_msgs/ImageMarker](http://docs.ros.org/api/visualization_msgs/html/msg/ImageMarker.html) can cause issues when the field names clash with reserved Rust keywords. 

This PR handles keyword fields as it's done in [genpy](https://github.com/ros/genpy/blob/52270603dd6b401064a1a5389d9c7092033c7d3a/src/genpy/generator.py#L226) by appending a `_` after the field name. Adds a new `FieldInfo` member, `generated_name` to distinguish between the .msg "name" (needed for MD5 calculation) and the Rust struct field name.