### PR TITLE
Replace deprecated rust-crypto lib.

### DIFF
--- a/rosrust_codegen/Cargo.toml
+++ b/rosrust_codegen/Cargo.toml
@@ -11,10 +11,12 @@ version = "0.7.0"
 error-chain = "0.11.0"
 lazy_static = "1.0.0"
 regex = "0.2.3"
-rust-crypto = "0.2.36"
 quote = "0.6.2"
 syn = "0.14.0"
 proc-macro2 = "0.4.3"
+digest = "0.8.0"
+md-5 = "0.8.0"
+hex = "0.3.2"
 
 [lib]
 proc-macro = true

--- a/rosrust_codegen/src/helpers.rs
+++ b/rosrust_codegen/src/helpers.rs
@@ -48,11 +48,10 @@ pub fn calculate_md5(message_map: &MessageMap) -> Result<HashMap<(String, String
 }
 
 fn calculate_md5_from_representation(v: &str) -> String {
-    use crypto::digest::Digest;
-    use crypto::md5::Md5;
+    use md5::{Digest, Md5};
     let mut hasher = Md5::new();
-    hasher.input_str(v);
-    hasher.result_str()
+    hasher.input(v);
+    hex::encode(hasher.result())
 }
 
 pub fn generate_message_definition<S: std::hash::BuildHasher>(

--- a/rosrust_codegen/src/helpers.rs
+++ b/rosrust_codegen/src/helpers.rs
@@ -48,6 +48,7 @@ pub fn calculate_md5(message_map: &MessageMap) -> Result<HashMap<(String, String
 }
 
 fn calculate_md5_from_representation(v: &str) -> String {
+    use hex;
     use md5::{Digest, Md5};
     let mut hasher = Md5::new();
     hasher.input(v);

--- a/rosrust_codegen/src/lib.rs
+++ b/rosrust_codegen/src/lib.rs
@@ -4,7 +4,9 @@ extern crate proc_macro;
 extern crate proc_macro2;
 #[macro_use]
 extern crate quote;
-extern crate crypto;
+extern crate digest;
+extern crate hex;
+extern crate md5;
 extern crate syn;
 #[macro_use]
 extern crate error_chain;

--- a/rosrust_codegen/src/msg.rs
+++ b/rosrust_codegen/src/msg.rs
@@ -109,11 +109,11 @@ impl Msg {
         &self,
         hashes: &HashMap<(String, String), String>,
     ) -> ::std::result::Result<String, ()> {
-        use crypto::digest::Digest;
-        use crypto::md5::Md5;
+        use md5::{Digest, Md5};
+
         let mut hasher = Md5::new();
-        hasher.input_str(&self.get_md5_representation(hashes)?);
-        Ok(hasher.result_str())
+        hasher.input(&self.get_md5_representation(hashes)?);
+        Ok(hex::encode(hasher.result().as_slice()))
     }
 
     pub fn get_md5_representation(


### PR DESCRIPTION
rust-crypto has been replaced by the (RustCrypto)[https://github.com/RustCrypto/] crates. In particular, rust-crypto does not compile on aarch64.

This PR replaces rust-crypto with the newer md-5 crate and the hex crate for encoding.