### PR TITLE
Clean up API exports to make it less confusing.

### DIFF
--- a/rosrust/src/lib.rs
+++ b/rosrust/src/lib.rs
@@ -18,12 +18,13 @@ extern crate serde_derive;
 extern crate xml_rpc;
 extern crate yaml_rust;
 
+pub use api::raii::Service;
 pub use api::{error, Clock, Parameter};
 pub use rosmsg::RosMsg;
 #[doc(hidden)]
 pub use rosrust_codegen::*;
 pub use singleton::*;
-pub use tcpros::{Client, Message, PublisherStream, ServicePair as Service};
+pub use tcpros::{Client, Message, PublisherStream, ServicePair};
 pub use time::{Duration, Time};
 
 pub mod api;

--- a/rosrust_codegen/src/output_layout.rs
+++ b/rosrust_codegen/src/output_layout.rs
@@ -152,7 +152,7 @@ impl Service {
                 }
             }
 
-            impl #crate_prefix Service for #name_ident {
+            impl #crate_prefix ServicePair for #name_ident {
                 type Request = #req_ident;
                 type Response = #res_ident;
             }


### PR DESCRIPTION
- Exporting `ServicePair as Service` means doing `let srv:
  rosrust::Service = rosrust::service...(...)` gives very confusing
  error messages about associated types.

- Open to not exporting the `api::raii::Service` type into `rosrust`
  but it seems like it should match the behavior of `Client` exports.