### PR TITLE
Adds rosrust::shutdown().

### DIFF
--- a/rosrust/src/singleton.rs
+++ b/rosrust/src/singleton.rs
@@ -88,6 +88,11 @@ pub fn spin() {
 }
 
 #[inline]
+pub fn shutdown() -> bool {
+    ros!().shutdown_sender().send(()).is_ok()
+}
+
+#[inline]
 pub fn param(name: &str) -> Option<Parameter> {
     ros!().param(name)
 }


### PR DESCRIPTION
Matches the rospy and rocpp APIs. Handy for multi-threaded shutdown.