### PR TITLE
Allow external connections when warranted.

### DIFF
--- a/rosrust/src/api/slave/mod.rs
+++ b/rosrust/src/api/slave/mod.rs
@@ -25,6 +25,7 @@ impl Slave {
     pub fn new(
         master_uri: &str,
         hostname: &str,
+        bind_address: &str,
         port: u16,
         name: &str,
         outer_shutdown_tx: Sender<()>,
@@ -38,7 +39,7 @@ impl Slave {
         let subscriptions = handler.subscriptions.clone();
         let services = Arc::clone(&handler.services);
         let (port_tx, port_rx) = channel();
-        let socket_addr = match (hostname, port).to_socket_addrs()?.next() {
+        let socket_addr = match (bind_address, port).to_socket_addrs()?.next() {
             Some(socket_addr) => socket_addr,
             None => bail!("Bad address provided: {}:{}", hostname, port),
         };


### PR DESCRIPTION
- Allow external machines to bind if the ROS_HOSTNAME/ROS_IP env vars
  are not set to a local address.

- Makes behavior match that of https://github.com/ros/ros_comm/blob/89ca9a7bf288b09d033a1ab6966ef8cfe39e1002/tools/rosgraph/src/rosgraph/network.py#L246

Addresses issue #55 