### PR TITLE
Fixes lack of matching when array is size 1.

### DIFF
--- a/rosrust/src/rosxmlrpc/client.rs
+++ b/rosrust/src/rosxmlrpc/client.rs
@@ -51,7 +51,7 @@ impl Client {
 }
 
 fn remove_array_wrappers(mut data: &[Value]) -> &[Value] {
-    while let [Value::Array(ref children), _] = data[..] {
+    while let [Value::Array(ref children)] = data[..] {
         data = children;
     }
     data


### PR DESCRIPTION
Registering `/rosout` failed for me on Kinetic because the message returned from the master was an Array of size 1, causing the `while let match` to skip immediately.