### PR TITLE
Prevent panic on XML RPC client connection failure.

### DIFF
--- a/rosrust/src/rosxmlrpc/error.rs
+++ b/rosrust/src/rosxmlrpc/error.rs
@@ -2,5 +2,13 @@ error_chain! {
     foreign_links {
         Io(::std::io::Error);
         Utf8(::std::string::FromUtf8Error);
+        ForeignXmlRpc(xml_rpc::error::Error);
+    }
+
+    errors {
+        TopicConnectionError(topic: String) {
+            description("Could not connect to topic")
+            display("Could not connect to {}", topic)
+        }
     }
 }


### PR DESCRIPTION
The unwraps here bring the whole system down if the XML connection fails.