### PR TITLE
Improve threading logic

### DIFF
--- a/rosrust/src/api/slave/handler.rs
+++ b/rosrust/src/api/slave/handler.rs
@@ -2,7 +2,7 @@ use super::publications::PublicationsTracker;
 use super::subscriptions::SubscriptionsTracker;
 use crate::rosxmlrpc::{self, Response, ResponseError, Server};
 use crate::tcpros::Service;
-use crossbeam::channel::Sender;
+use crate::util::kill;
 use log::{error, info};
 use nix::unistd::getpid;
 use std::collections::HashMap;
@@ -29,7 +29,7 @@ impl SlaveHandler {
         master_uri: &str,
         hostname: &str,
         name: &str,
-        shutdown_signal: Sender<()>,
+        shutdown_signal: kill::Sender,
     ) -> SlaveHandler {
         let mut server = Server::default();
 
@@ -59,7 +59,7 @@ impl SlaveHandler {
                 _ => return Err(ResponseError::Client("Missing argument 'message'".into())),
             };
             info!("Server is shutting down because: {}", message);
-            match shutdown_signal.clone().send(()) {
+            match shutdown_signal.send() {
                 Ok(()) => Ok(Value::Int(0)),
                 Err(err) => {
                     error!("Shutdown error: {:?}", err);

--- a/rosrust/src/api/slave/mod.rs
+++ b/rosrust/src/api/slave/mod.rs
@@ -6,8 +6,8 @@ use self::handler::SlaveHandler;
 use super::error::{self, ErrorKind, Result};
 use crate::api::ShutdownManager;
 use crate::tcpros::{Message, PublisherStream, Service, ServicePair, ServiceResult};
-use crate::util::{CROSSBEAM_CHANNEL_UNEXPECTEDLY_CLOSED, FAILED_TO_LOCK};
-use crossbeam::channel::{bounded, Sender, TryRecvError};
+use crate::util::{kill, FAILED_TO_LOCK};
+use crossbeam::channel::TryRecvError;
 use log::error;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -19,7 +19,7 @@ pub struct Slave {
     pub publications: publications::PublicationsTracker,
     pub subscriptions: subscriptions::SubscriptionsTracker,
     pub services: Arc<Mutex<HashMap<String, Service>>>,
-    pub shutdown_tx: Sender<()>,
+    pub shutdown_tx: kill::Sender,
 }
 
 type SerdeResult<T> = Result<T>;
@@ -35,12 +35,11 @@ impl Slave {
     ) -> Result<Slave> {
         use std::net::ToSocketAddrs;
 
-        let (shutdown_tx, shutdown_rx) = bounded(0);
+        let (shutdown_tx, shutdown_rx) = kill::channel(kill::KillMode::Sync);
         let handler = SlaveHandler::new(master_uri, hostname, name, shutdown_tx.clone());
         let publications = handler.publications.clone();
         let subscriptions = handler.subscriptions.clone();
         let services = Arc::clone(&handler.services);
-        let (port_tx, port_rx) = bounded(1);
         let socket_addr = match (bind_address, port).to_socket_addrs()?.next() {
             Some(socket_addr) => socket_addr,
             None => bail!(error::ErrorKind::from(error::rosxmlrpc::ErrorKind::BadUri(
@@ -48,20 +47,12 @@ impl Slave {
             ))),
         };
 
+        let bound_handler = handler.bind(&socket_addr)?;
+
+        let port = bound_handler.local_addr().port();
+        let uri = format!("http://{}:{}/", hostname, port);
+
         thread::spawn(move || {
-            let bound_handler = match handler.bind(&socket_addr) {
-                Ok(v) => v,
-                Err(err) => {
-                    port_tx
-                        .send(Err(err))
-                        .expect(CROSSBEAM_CHANNEL_UNEXPECTEDLY_CLOSED);
-                    return;
-                }
-            };
-            let port = bound_handler.local_addr().port();
-            port_tx
-                .send(Ok(port))
-                .expect(CROSSBEAM_CHANNEL_UNEXPECTEDLY_CLOSED);
             loop {
                 match shutdown_rx.try_recv() {
                     Ok(_) | Err(TryRecvError::Disconnected) => break,
@@ -73,11 +64,6 @@ impl Slave {
             }
             shutdown_manager.shutdown();
         });
-
-        let port = port_rx
-            .recv()
-            .expect(CROSSBEAM_CHANNEL_UNEXPECTEDLY_CLOSED)?;
-        let uri = format!("http://{}:{}/", hostname, port);
 
         Ok(Slave {
             name: String::from(name),

--- a/rosrust/src/tcpros/publisher.rs
+++ b/rosrust/src/tcpros/publisher.rs
@@ -108,7 +108,14 @@ impl Publisher {
     {
         let listener = TcpListener::bind(address)?;
         let socket_address = listener.local_addr()?;
-        let (raii, listener) = tcpconnection::iterate(listener, format!("topic '{}'", topic));
+        // We will queue up to 8 connection requests to be processed before blocking the
+        // connection receiving thread.
+        let tcp_listener_queue_size = 8;
+        let (raii, listener) = tcpconnection::iterate(
+            listener,
+            format!("topic '{}'", topic),
+            Some(tcp_listener_queue_size),
+        );
         Ok(Publisher::wrap_stream::<T, _, _>(
             topic,
             raii,

--- a/rosrust/src/tcpros/service.rs
+++ b/rosrust/src/tcpros/service.rs
@@ -8,15 +8,21 @@ use log::error;
 use std;
 use std::collections::HashMap;
 use std::io;
-use std::net::TcpListener;
-use std::sync::Arc;
+use std::net::{TcpListener, TcpStream};
+use std::sync::{atomic, Arc};
 use std::thread;
 
 pub struct Service {
     pub api: String,
     pub msg_type: String,
     pub service: String,
-    _raii: tcpconnection::Raii,
+    exists: Arc<atomic::AtomicBool>,
+}
+
+impl Drop for Service {
+    fn drop(&mut self) {
+        self.exists.store(false, atomic::Ordering::SeqCst);
+    }
 }
 
 impl Service {
@@ -35,44 +41,31 @@ impl Service {
         let listener = TcpListener::bind((bind_address, port))?;
         let socket_address = listener.local_addr()?;
         let api = format!("rosrpc://{}:{}", hostname, socket_address.port());
-        // We will queue up to 8 connection requests to be processed before blocking the
-        // connection receiving thread.
-        let tcp_listener_queue_size = 8;
-        let (raii, listener) = tcpconnection::iterate(
-            listener,
-            format!("service '{}'", service),
-            Some(tcp_listener_queue_size),
-        );
-        Ok(Service::wrap_stream::<T, _, _, _>(
-            service, node_name, handler, raii, listener, &api,
-        ))
-    }
 
-    fn wrap_stream<T, U, V, F>(
-        service: &str,
-        node_name: &str,
-        handler: F,
-        raii: tcpconnection::Raii,
-        listener: V,
-        api: &str,
-    ) -> Service
-    where
-        T: ServicePair,
-        U: std::io::Read + std::io::Write + Send + 'static,
-        V: Iterator<Item = U> + Send + 'static,
-        F: Fn(T::Request) -> ServiceResult<T::Response> + Send + Sync + 'static,
-    {
-        let service_name = String::from(service);
-        let node_name = String::from(node_name);
-        thread::spawn(move || {
-            listen_for_clients::<T, _, _, _>(&service_name, &node_name, handler, listener)
-        });
-        Service {
+        let service_exists = Arc::new(atomic::AtomicBool::new(true));
+
+        let iterate_handler = {
+            let service_exists = service_exists.clone();
+            let service = String::from(service);
+            let node_name = String::from(node_name);
+            let handler = Arc::new(handler);
+            move |stream: TcpStream| {
+                if !service_exists.load(atomic::Ordering::SeqCst) {
+                    return tcpconnection::Feedback::StopAccepting;
+                }
+                consume_client::<T, _, _>(&service, &node_name, Arc::clone(&handler), stream);
+                return tcpconnection::Feedback::AcceptNextStream;
+            }
+        };
+
+        tcpconnection::iterate(listener, format!("service '{}'", service), iterate_handler);
+
+        Ok(Service {
             api: String::from(api),
             msg_type: T::msg_type(),
             service: String::from(service),
-            _raii: raii,
-        }
+            exists: service_exists,
+        })
     }
 }
 
@@ -81,34 +74,28 @@ enum RequestType {
     Action,
 }
 
-fn listen_for_clients<T, U, V, F>(service: &str, node_name: &str, handler: F, connections: V)
+fn consume_client<T, U, F>(service: &str, node_name: &str, handler: Arc<F>, mut stream: U)
 where
     T: ServicePair,
     U: std::io::Read + std::io::Write + Send + 'static,
-    V: Iterator<Item = U>,
     F: Fn(T::Request) -> ServiceResult<T::Response> + Send + Sync + 'static,
 {
-    let handler = Arc::new(handler);
-    for mut stream in connections {
-        // Service request starts by exchanging connection headers
-        match exchange_headers::<T, _>(&mut stream, service, node_name) {
-            Err(err) => {
-                // Connection can be closed when a client checks for a service.
-                if !err.is_closed_connection() {
-                    error!(
-                        "Failed to exchange headers for service '{}': {}",
-                        service, err
-                    );
-                }
-                continue;
+    // Service request starts by exchanging connection headers
+    match exchange_headers::<T, _>(&mut stream, service, node_name) {
+        Err(err) => {
+            // Connection can be closed when a client checks for a service.
+            if !err.is_closed_connection() {
+                error!(
+                    "Failed to exchange headers for service '{}': {}",
+                    service, err
+                );
             }
-
-            // Spawn a thread for handling requests
-            Ok(RequestType::Action) => {
-                spawn_request_handler::<T, U, F>(stream, Arc::clone(&handler))
-            }
-            Ok(RequestType::Probe) => (),
+            return;
         }
+
+        // Spawn a thread for handling requests
+        Ok(RequestType::Action) => spawn_request_handler::<T, U, F>(stream, Arc::clone(&handler)),
+        Ok(RequestType::Probe) => (),
     }
 }
 
@@ -181,6 +168,7 @@ where
     // TODO: validate message length
     let _length = stream.read_u32::<LittleEndian>();
     // Break out of loop in case of failure to read request
+    // TODO: handle retained connections
     if let Ok(req) = RosMsg::decode(&mut stream) {
         // Call function that handles request and returns response
         match handler(req) {

--- a/rosrust/src/tcpros/subscriber.rs
+++ b/rosrust/src/tcpros/subscriber.rs
@@ -102,11 +102,7 @@ where
     T: Message,
     F: Fn(T) -> (),
 {
-    for buffer_option in data {
-        let buffer = match buffer_option {
-            Some(v) => v,
-            None => break, // Only the Subscriber destructor can send this signal
-        };
+    for buffer in data {
         match RosMsg::decode_slice(&buffer) {
             Ok(value) => callback(value),
             Err(err) => error!("Failed to decode message: {}", err),

--- a/rosrust/src/tcpros/subscriber.rs
+++ b/rosrust/src/tcpros/subscriber.rs
@@ -4,7 +4,7 @@ use super::{Message, Topic};
 use crate::rosmsg::RosMsg;
 use crate::util::lossy_channel::{lossy_channel, LossyReceiver, LossySender};
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use crossbeam::channel::{unbounded, Receiver, Sender, TrySendError};
+use crossbeam::channel::{bounded, Receiver, Sender, TrySendError};
 use log::error;
 use std;
 use std::collections::{BTreeSet, HashMap};
@@ -25,7 +25,8 @@ impl Subscriber {
         F: Fn(T) -> () + Send + 'static,
     {
         let (data_tx, data_rx) = lossy_channel(queue_size);
-        let (pub_tx, pub_rx) = unbounded();
+        let publisher_connection_queue_size = 8;
+        let (pub_tx, pub_rx) = bounded(publisher_connection_queue_size);
         let caller_id = String::from(caller_id);
         let topic_name = String::from(topic);
         let data_stream = data_tx.clone();

--- a/rosrust/src/tcpros/util/streamfork.rs
+++ b/rosrust/src/tcpros/util/streamfork.rs
@@ -71,7 +71,7 @@ impl<T: Write + Send + 'static> ForkThread<T> {
         data: &LossyReceiver<Arc<Vec<u8>>>,
     ) -> Result<(), channel::RecvError> {
         channel::select! {
-            recv(data.kill_rx) -> msg => {
+            recv(data.kill_rx.kill_rx) -> msg => {
                 return msg.and(Err(channel::RecvError));
             }
             recv(data.data_rx) -> msg => {

--- a/rosrust/src/tcpros/util/tcpconnection.rs
+++ b/rosrust/src/tcpros/util/tcpconnection.rs
@@ -1,20 +1,13 @@
-use crossbeam::channel::{self, bounded, unbounded, Receiver, Sender};
+use crate::util::killable_channel::{channel, KillMode, Killer, Receiver, SendMode, Sender};
 use log::error;
 use std::net::{TcpListener, TcpStream};
 use std::thread;
 
 pub fn iterate(listener: TcpListener, tag: String) -> (Raii, TcpConnectionIterator) {
-    let (tcp_stream_tx, tcp_stream_rx) = unbounded();
-    let (kill_tx, kill_rx) = bounded(0);
-    let killer = Raii { kill_tx };
+    let (killer, tcp_stream_tx, tcp_stream_rx) = channel(SendMode::Unbounded, KillMode::Sync);
+    let killer = Raii { killer };
     thread::spawn(move || listener_thread(&listener, &tag, &tcp_stream_tx));
-    (
-        killer,
-        TcpConnectionIterator {
-            tcp_stream_rx,
-            kill_rx,
-        },
-    )
+    (killer, tcp_stream_rx)
 }
 
 fn listener_thread(connections: &TcpListener, tag: &str, out: &Sender<TcpStream>) {
@@ -32,30 +25,15 @@ fn listener_thread(connections: &TcpListener, tag: &str, out: &Sender<TcpStream>
     }
 }
 
-pub struct TcpConnectionIterator {
-    tcp_stream_rx: Receiver<TcpStream>,
-    kill_rx: Receiver<()>,
-}
-
-impl Iterator for TcpConnectionIterator {
-    type Item = TcpStream;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        channel::select! {
-            recv(self.tcp_stream_rx) -> msg => msg.ok(),
-            recv(self.kill_rx) -> _ => None,
-        }
-    }
-}
+pub type TcpConnectionIterator = Receiver<TcpStream>;
 
 pub struct Raii {
-    kill_tx: Sender<()>,
+    killer: Killer,
 }
 
 impl Drop for Raii {
     fn drop(&mut self) {
-        let send_result = self.kill_tx.send(());
-        if send_result.is_err() {
+        if self.killer.send().is_err() {
             error!("TCP connection listener has already been killed");
         }
     }

--- a/rosrust/src/tcpros/util/tcpconnection.rs
+++ b/rosrust/src/tcpros/util/tcpconnection.rs
@@ -1,4 +1,4 @@
-use crossbeam::channel::{bounded, select, unbounded, Receiver, Sender};
+use crossbeam::channel::{self, bounded, unbounded, Receiver, Sender};
 use log::error;
 use std::net::{TcpListener, TcpStream};
 use std::thread;
@@ -41,7 +41,7 @@ impl Iterator for TcpConnectionIterator {
     type Item = TcpStream;
 
     fn next(&mut self) -> Option<Self::Item> {
-        select! {
+        channel::select! {
             recv(self.tcp_stream_rx) -> msg => msg.ok(),
             recv(self.kill_rx) -> _ => None,
         }

--- a/rosrust/src/util/kill.rs
+++ b/rosrust/src/util/kill.rs
@@ -1,0 +1,41 @@
+use crossbeam::channel;
+
+pub enum KillMode {
+    Sync,
+    Async,
+}
+
+impl KillMode {
+    fn into_channel<T>(self) -> (channel::Sender<T>, channel::Receiver<T>) {
+        match self {
+            KillMode::Sync => channel::bounded(0),
+            KillMode::Async => channel::unbounded(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct Sender {
+    pub kill_tx: channel::Sender<()>,
+}
+
+impl Sender {
+    pub fn send(&self) -> Result<(), channel::SendError<()>> {
+        self.kill_tx.send(())
+    }
+}
+
+pub struct Receiver {
+    pub kill_rx: channel::Receiver<()>,
+}
+
+impl Receiver {
+    pub fn try_recv(&self) -> Result<(), channel::TryRecvError> {
+        self.kill_rx.try_recv()
+    }
+}
+
+pub fn channel(kill_mode: KillMode) -> (Sender, Receiver) {
+    let (kill_tx, kill_rx) = kill_mode.into_channel();
+    (Sender { kill_tx }, Receiver { kill_rx })
+}

--- a/rosrust/src/util/killable_channel.rs
+++ b/rosrust/src/util/killable_channel.rs
@@ -1,0 +1,45 @@
+use super::kill;
+pub use super::kill::KillMode;
+use crossbeam::channel;
+pub use crossbeam::channel::Sender;
+
+pub struct Receiver<T> {
+    pub data_rx: channel::Receiver<T>,
+    pub kill_rx: kill::Receiver,
+}
+
+impl<T> Iterator for Receiver<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        channel::select! {
+            recv(self.data_rx) -> msg => msg.ok(),
+            recv(self.kill_rx.kill_rx) -> _ => None,
+        }
+    }
+}
+
+pub type Killer = kill::Sender;
+
+#[allow(dead_code)]
+pub enum SendMode {
+    Sync,
+    Bounded(usize),
+    Unbounded,
+}
+
+impl SendMode {
+    fn into_channel<T>(self) -> (channel::Sender<T>, channel::Receiver<T>) {
+        match self {
+            SendMode::Sync => channel::bounded(0),
+            SendMode::Bounded(queue_size) => channel::bounded(queue_size),
+            SendMode::Unbounded => channel::unbounded(),
+        }
+    }
+}
+
+pub fn channel<T>(send_mode: SendMode, kill_mode: KillMode) -> (Killer, Sender<T>, Receiver<T>) {
+    let (data_tx, data_rx) = send_mode.into_channel();
+    let (kill_tx, kill_rx) = kill::channel(kill_mode);
+    (kill_tx, data_tx, Receiver { data_rx, kill_rx })
+}

--- a/rosrust/src/util/lossy_channel.rs
+++ b/rosrust/src/util/lossy_channel.rs
@@ -1,17 +1,22 @@
 use crate::util::FAILED_TO_LOCK;
-use crossbeam::channel::{unbounded, Receiver, SendError, Sender, TrySendError};
+use crossbeam::channel::{self, unbounded, Receiver, Sender};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 #[allow(clippy::mutex_atomic)]
 pub fn lossy_channel<T>(queue_size: usize) -> (LossySender<T>, LossyReceiver<T>) {
-    let (tx, rx) = unbounded();
+    let (data_tx, data_rx) = unbounded();
+    let (kill_tx, kill_rx) = unbounded();
     let is_open = Arc::new(AtomicBool::new(true));
-    let receiver = rx.clone();
+    let receiver = LossyReceiver {
+        data_rx: data_rx.clone(),
+        kill_rx,
+    };
     let queue_size = Arc::new(Mutex::new(queue_size));
     let sender = LossySender {
-        tx,
-        rx,
+        data_tx,
+        data_rx,
+        kill_tx,
         is_open,
         queue_size,
     };
@@ -20,32 +25,34 @@ pub fn lossy_channel<T>(queue_size: usize) -> (LossySender<T>, LossyReceiver<T>)
 
 #[derive(Clone)]
 pub struct LossySender<T> {
-    tx: Sender<Option<T>>,
-    rx: Receiver<Option<T>>,
+    data_tx: Sender<T>,
+    data_rx: Receiver<T>,
+    kill_tx: Sender<()>,
     is_open: Arc<AtomicBool>,
     pub queue_size: Arc<Mutex<usize>>,
 }
 
 impl<T> LossySender<T> {
-    pub fn try_send(&self, msg: T) -> Result<(), TrySendError<Option<T>>> {
+    pub fn try_send(&self, msg: T) -> Result<(), channel::TrySendError<T>> {
         if !self.is_open.load(Ordering::SeqCst) {
-            return Err(TrySendError::Disconnected(Some(msg)));
+            return Err(channel::TrySendError::Disconnected(msg));
         }
-        self.tx.try_send(Some(msg))?;
+        self.data_tx.try_send(msg)?;
         self.remove_extra_data();
         Ok(())
     }
 
-    pub fn close(&self) -> Result<(), SendError<Option<T>>> {
+    pub fn close(&self) -> Result<(), channel::SendError<()>> {
         self.is_open.store(false, Ordering::SeqCst);
-        self.tx.send(None)
+        self.kill_tx.send(())
     }
 
     fn remove_extra_data(&self) {
         let queue_size: usize = *self.queue_size.lock().expect(FAILED_TO_LOCK);
-        while self.rx.len() > queue_size {
-            if self.rx.try_recv().is_err() {
+        while self.data_rx.len() > queue_size {
+            if self.data_rx.try_recv().is_err() {
                 log::error!("Failed to remove excess data from message queue");
+                break;
             }
         }
     }
@@ -60,4 +67,18 @@ impl<T> LossySender<T> {
     }
 }
 
-pub type LossyReceiver<T> = Receiver<Option<T>>;
+pub struct LossyReceiver<T> {
+    pub data_rx: Receiver<T>,
+    pub kill_rx: Receiver<()>,
+}
+
+impl<T> Iterator for LossyReceiver<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        channel::select! {
+            recv(self.data_rx) -> msg => msg.ok(),
+            recv(self.kill_rx) -> _ => None,
+        }
+    }
+}

--- a/rosrust/src/util/mod.rs
+++ b/rosrust/src/util/mod.rs
@@ -1,5 +1,5 @@
+pub mod kill;
+pub mod killable_channel;
 pub mod lossy_channel;
 
 pub static FAILED_TO_LOCK: &'static str = "Failed to acquire lock";
-pub static CROSSBEAM_CHANNEL_UNEXPECTEDLY_CLOSED: &'static str =
-    "Crossbeam channel unexpectedly closed on one end";

--- a/rosrust/src/util/mod.rs
+++ b/rosrust/src/util/mod.rs
@@ -1,5 +1,5 @@
 pub mod lossy_channel;
 
 pub static FAILED_TO_LOCK: &'static str = "Failed to acquire lock";
-pub static MPSC_CHANNEL_UNEXPECTEDLY_CLOSED: &'static str =
-    "MPSC channel unexpectedly closed on one end";
+pub static CROSSBEAM_CHANNEL_UNEXPECTEDLY_CLOSED: &'static str =
+    "Crossbeam channel unexpectedly closed on one end";


### PR DESCRIPTION
Crossbeam allowed for some interactions that the standard library didn't.

This allowed reducing threads and making the intent of some channels clearer.