### PR TITLE
Adds is_initialized to check for rosrust init state.

### DIFF
--- a/rosrust/src/singleton.rs
+++ b/rosrust/src/singleton.rs
@@ -41,6 +41,10 @@ pub fn try_init_with_options(name: &str, capture_sigint: bool) -> Result<()> {
     Ok(())
 }
 
+pub fn is_initialized() -> bool {
+    ROS.read().expect(FAILED_TO_LOCK).is_some()
+}
+
 macro_rules! ros {
     () => {
         ROS.read()


### PR DESCRIPTION
Without this there's no way to avoid a panic when making a `rosrust` API call.