### PR TITLE
Better error message when .msg file not found

### DIFF
--- a/rosrust_codegen/src/error.rs
+++ b/rosrust_codegen/src/error.rs
@@ -4,4 +4,11 @@ error_chain! {
     foreign_links {
         Regex(::regex::Error);
     }
+
+    errors {
+        MessageNotFound(msg: String, folders: String) {
+            description("message not found in provided directories")
+            display("message {} not found in provided directories\nDirectories:\n{}", msg, folders)
+        }
+    }
 }

--- a/rosrust_codegen/src/helpers.rs
+++ b/rosrust_codegen/src/helpers.rs
@@ -1,4 +1,4 @@
-use crate::error::{Result, ResultExt};
+use crate::error::{Result, ResultExt, ErrorKind};
 use crate::msg::Msg;
 use lazy_static::lazy_static;
 use regex::RegexBuilder;
@@ -201,10 +201,7 @@ fn get_message(folders: &[&str], package: &str, name: &str) -> Result<MessageCas
     if let Some(contents) = IN_MEMORY_MESSAGES.get(format!("{}/{}", package, name).as_str()) {
         return Msg::new(package, name, contents).map(MessageCase::Message);
     }
-    bail!(format!(
-        "Could not find requested message in provided folders: {}/{}",
-        package, name
-    ));
+    bail!(ErrorKind::MessageNotFound(format!("{}/{}", package, name), folders.join("\n")));
 }
 
 #[cfg(test)]

--- a/rosrust_codegen/src/rosmsg_include.rs
+++ b/rosrust_codegen/src/rosmsg_include.rs
@@ -27,7 +27,7 @@ pub fn depend_on_messages(messages: &[&str], internal: bool) -> TokenStream {
         .map(String::as_str)
         .collect::<Vec<&str>>();
     let output = genmsg::depend_on_messages(paths.as_slice(), messages)
-        .unwrap()
+        .unwrap_or_else(|r| panic!("{}", r))
         .token_stream(&if internal {
             quote! { crate:: }
         } else {


### PR DESCRIPTION
If a .msg file is not found (e.g. because the root ROS overlay has not been sourced with `source /opt/ros/$ROSDISTRO/setup.bash`), the current error message is a bit confusing, as it focuses on the "unwrap". A novice to the library may think that the error is due to a problem in the code, and not of his own setup:

```
warning: build failed, waiting for other jobs to finish...
error: proc macro panicked
 --> rosrust_diagnostics/src/msg.rs:4:1
  |
4 | rosrust::rosmsg_include!(diagnostic_msgs / DiagnosticArray);
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = help: message: called `Result::unwrap()` on an `Err` value: Error(Msg("Could not find requested message in provided folders: diagnostic_msgs/DiagnosticArray"), State { next_error: None, backtrace: None })

error: aborting due to previous error
error: Could not compile `camera`.

```

This change makes the message more clearly focused on the root of the problem:

```
error: proc macro panicked
 --> examples/camera/src/msg.rs:1:1
  |
1 | rosrust::rosmsg_include!(sensor_msgs / Image);
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = help: message: message sensor_msgs/Image not found in provided directories
          Directories:
          share
          ../src
          

error: aborting due to previous error
error: Could not compile `camera`.

```

We could also make the message even smarter, by detecting the $ROSDISTRO environment variable, and suggesting the user to source a workspace if it is empty.