### PR TITLE
Upgrade error chain and make linking to tcpros errors possible.

### DIFF
--- a/rosrust/Cargo.toml
+++ b/rosrust/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.8.1"
 [dependencies]
 byteorder = "1.2.3"
 ctrlc = "3.0.3"
-error-chain = "0.11.0"
+error-chain = "0.12"
 lazy_static = "1.0.0"
 log = "0.4.0"
 nix = "0.9.0"

--- a/rosrust/src/lib.rs
+++ b/rosrust/src/lib.rs
@@ -21,6 +21,6 @@ pub mod msg;
 pub mod rosmsg;
 mod rosxmlrpc;
 pub mod singleton;
-pub mod tcpros;
+mod tcpros;
 mod time;
 mod util;

--- a/rosrust/src/lib.rs
+++ b/rosrust/src/lib.rs
@@ -21,6 +21,6 @@ pub mod msg;
 pub mod rosmsg;
 mod rosxmlrpc;
 pub mod singleton;
-mod tcpros;
+pub mod tcpros;
 mod time;
 mod util;


### PR DESCRIPTION
Exposing tcpros as `pub` to link with error-chain to the errors from there which get propagated up, using e.g. ```
links {
 RosrustTcpError(rosrust::tcpros::error::Error,
                        rosrust::tcpros::error::ErrorKind)
}```