### PR TITLE
Diagnostics: CompositeTask adds by ref, not owned.

### DIFF
--- a/rosrust_diagnostics/examples/example.rs
+++ b/rosrust_diagnostics/examples/example.rs
@@ -84,8 +84,11 @@ fn main() {
     updater.add_task(&dummy_task).unwrap();
 
     let mut bounds = CompositeTask::new("Bound check");
-    bounds.add_task(check_lower_bound.into_task("Lower-bound check"));
-    bounds.add_task(check_upper_bound.into_task("Upper-bound check"));
+
+    let lower_task = check_lower_bound.into_task("Lower-bound check");
+    let upper_task = check_upper_bound.into_task("Upper-bound check");
+    bounds.add_task(&lower_task);
+    bounds.add_task(&upper_task);
 
     updater.add_task(&bounds).unwrap();
 

--- a/rosrust_diagnostics/src/composite_task.rs
+++ b/rosrust_diagnostics/src/composite_task.rs
@@ -13,12 +13,12 @@ use crate::{Level, Status, Task};
 /// takes ownership of tasks. To maintain ownership, and manage things optimally
 /// implement your own `Task`, by utilizing the `run_diagnostics!` macro for
 /// similar functionality.
-pub struct CompositeTask {
+pub struct CompositeTask<'a> {
     name: String,
-    tasks: Vec<Box<dyn Task>>,
+    tasks: Vec<&'a Task>,
 }
 
-impl CompositeTask {
+impl<'a> CompositeTask<'a> {
     /// Creates a new composite task with the given name.
     pub fn new(name: impl std::string::ToString) -> Self {
         Self {
@@ -30,12 +30,12 @@ impl CompositeTask {
     /// Adds a child to the composite task.
     ///
     /// This child will be called every time the composit task is called.
-    pub fn add_task(&mut self, task: impl Task + 'static) {
-        self.tasks.push(Box::new(task))
+    pub fn add_task(&mut self, task: &'a dyn Task) {
+        self.tasks.push(task)
     }
 }
 
-impl Task for CompositeTask {
+impl<'a> Task for CompositeTask<'a> {
     #[inline]
     fn name(&self) -> &str {
         &self.name


### PR DESCRIPTION
Adding to a CompositeTask via owned tasks means the same task cannot be added to a composite that can be added to an updater. Also seems to prevent adding something (like a `FrequencyStatus`) which is owned by an Arc, as `Arc<FrequencyStatus>` does not `impl Task` AFAICT.