### PR TITLE
Add message definition to publisher message header

### DIFF
--- a/rosrust/src/tcpros/publisher.rs
+++ b/rosrust/src/tcpros/publisher.rs
@@ -58,6 +58,7 @@ fn write_response<T: Message, U: std::io::Write>(
     fields.insert(String::from("md5sum"), T::md5sum());
     fields.insert(String::from("type"), T::msg_type());
     fields.insert(String::from("callerid"), caller_id.into());
+    fields.insert(String::from("message_definition"), T::msg_definition());
     header::encode(&mut stream, &fields)?;
     Ok(())
 }


### PR DESCRIPTION
This fixes dynamic subscribers storing/interpreting the message definition, and therefore recorded bags having empty definitions that do not match the MD5.