### PR TITLE
added SIGTERM support

### DIFF
--- a/rosrust/Cargo.toml
+++ b/rosrust/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.9.2"
 
 [dependencies]
 byteorder = "1.3.2"
-ctrlc = "3.1.3"
+ctrlc = {version="3.1.3", features=["termination"]}
 error-chain = "0.12.1"
 lazy_static = "1.4.0"
 log = "0.4.8"


### PR DESCRIPTION
I'm not entirely sure why SIGTERM handling isn't the default in `ctrlc`, but it isn't, so this is required to make a rosrust application respond to that signal gracefully.