### PR TITLE
added serde derives for messages

### DIFF
--- a/rosrust/Cargo.toml
+++ b/rosrust/Cargo.toml
@@ -29,6 +29,9 @@ regex = "1.3.1"
 criterion = "0.3.0"
 env_logger = "0.7.1"
 
+[features]
+derive-serde = ["rosrust_codegen/derive-serde"]
+
 [[bench]]
 name = "benchmarks"
 harness = false

--- a/rosrust_codegen/Cargo.toml
+++ b/rosrust_codegen/Cargo.toml
@@ -19,5 +19,8 @@ digest = "0.8.1"
 md-5 = "0.8.0"
 hex = "0.4.0"
 
+[features]
+derive-serde = []
+
 [lib]
 proc-macro = true

--- a/rosrust_codegen/src/msg.rs
+++ b/rosrust_codegen/src/msg.rs
@@ -65,9 +65,9 @@ impl Msg {
             .map(|v| v.const_token_stream(crate_prefix))
             .collect::<Vec<_>>();
         let serde_derives = if cfg!(feature = "derive-serde") {
-            quote! { #[derive(::serde::Serialize, ::serde::Deserialize)] };
+            quote! { #[derive(::serde::Serialize, ::serde::Deserialize)] }
         } else {
-            quote! {};
+            quote! {}
         };
         quote! {
             #[allow(dead_code, non_camel_case_types, non_snake_case)]

--- a/rosrust_codegen/src/msg.rs
+++ b/rosrust_codegen/src/msg.rs
@@ -64,8 +64,14 @@ impl Msg {
             .iter()
             .map(|v| v.const_token_stream(crate_prefix))
             .collect::<Vec<_>>();
+        let serde_derives = if cfg!(feature = "derive-serde") {
+            quote! { #[derive(::serde::Serialize, ::serde::Deserialize)] };
+        } else {
+            quote! {};
+        };
         quote! {
             #[allow(dead_code, non_camel_case_types, non_snake_case)]
+            #serde_derives
             #[derive(Clone)]
             pub struct #name {
                 #(#fields)*


### PR DESCRIPTION
This PR adds a `derive-serde` feature flag so that generated mesages can be sent over non-ROS transport layers.  

I couldn't figure out how to build rosrust, so I have no idea if this compiles, please forgive obvious mistakes.