### PR TITLE
github action to build rosrust in Ubuntu 20.04 with ros noetic

### DIFF
--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -1,0 +1,104 @@
+name: Ubuntu 20.04 Noetic rosrust
+
+# on: [push]
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    env:
+      ROS_CI_DESKTOP: "`lsb_release -cs`"  # e.g. [trusty|xenial|...]
+      # CI_SOURCE_PATH: $(pwd)
+      ROSINSTALL_FILE: $CI_SOURCE_PATH/dependencies.rosinstall
+      CATKIN_OPTIONS: $CI_SOURCE_PATH/catkin.options
+      ROS_PARALLEL_JOBS: '-j8 -l6'
+      # Set the python path manually to include /usr/-/python2.7/dist-packages
+      # as this is where apt-get installs python packages.
+      PYTHONPATH: $PYTHONPATH:/usr/lib/python2.7/dist-packages:/usr/local/lib/python2.7/dist-packages
+      ROS_DISTRO: noetic
+    steps:
+      - name: rosrust
+        uses: actions/checkout@v1
+      - name: Install latest rust
+        run: |
+            curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | sh -s -- -y
+            rustc --version
+            cargo --version
+      - name: Configure ROS for install
+        run: |
+            sudo sh -c "echo \"deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main\" > /etc/apt/sources.list.d/ros-latest.list"
+            sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+            sudo apt-get update -qq
+            sudo apt-get install dpkg
+            sudo apt-get install -y libyaml-cpp-dev
+      - name: Install ROS basic packages
+        run: |
+            sudo apt-get install -y python3-catkin-pkg
+            sudo apt-get install -y python3-catkin-tools
+            sudo apt-get install -y python3-rosdep
+            sudo apt-get install -y python3-wstool
+            sudo apt-get install -y python3-osrf-pycommon
+            sudo apt-get install -y ros-cmake-modules
+            sudo apt-get install -y ros-$ROS_DISTRO-ros-base
+            source /opt/ros/$ROS_DISTRO/setup.bash
+            sudo rosdep init
+            rosdep update  # --include-eol-distros  # Support EOL distros.
+      - name: Install ROS additional packages (TODO maybe don't need these)
+        # Does installing these mean rosrust_msg builds more messages, which is a better
+        # check?  Or does it just slow down the action?
+        run: |
+            sudo apt-get install -y ros-$ROS_DISTRO-actionlib
+            sudo apt-get install -y ros-$ROS_DISTRO-actionlib-msgs
+            sudo apt-get install -y ros-$ROS_DISTRO-camera-info-manager
+            sudo apt-get install -y ros-$ROS_DISTRO-compressed-image-transport
+            sudo apt-get install -y ros-$ROS_DISTRO-catkin
+            sudo apt-get install -y ros-$ROS_DISTRO-class-loader
+            sudo apt-get install -y ros-$ROS_DISTRO-cmake-modules
+            sudo apt-get install -y ros-$ROS_DISTRO-cv-bridge
+            sudo apt-get install -y ros-$ROS_DISTRO-dynamic-reconfigure
+            sudo apt-get install -y ros-$ROS_DISTRO-ddynamic-reconfigure
+            # Not in noetic yet
+            # sudo apt-get install -y ros-$ROS_DISTRO-ddynamic-reconfigure-python
+            sudo apt-get install -y ros-$ROS_DISTRO-eigen-conversions
+            sudo apt-get install -y ros-$ROS_DISTRO-geometry-msgs
+            sudo apt-get install -y ros-$ROS_DISTRO-genmsg
+            sudo apt-get install -y ros-$ROS_DISTRO-image-geometry
+            sudo apt-get install -y ros-$ROS_DISTRO-image-proc
+            sudo apt-get install -y ros-$ROS_DISTRO-image-transport
+            sudo apt-get install -y ros-$ROS_DISTRO-message-generation
+            sudo apt-get install -y ros-$ROS_DISTRO-message-runtime
+            # sudo apt-get install -y ros-$ROS_DISTRO-nodelet-core
+            # sudo apt-get install -y ros-$ROS_DISTRO-nodelet-topic-tools
+            # sudo apt-get install -y ros-$ROS_DISTRO-pcl-conversions
+            # sudo apt-get install -y ros-$ROS_DISTRO-pcl-ros
+            sudo apt-get install -y ros-$ROS_DISTRO-pluginlib
+            sudo apt-get install -y ros-$ROS_DISTRO-roscpp
+            sudo apt-get install -y ros-$ROS_DISTRO-roslib
+            sudo apt-get install -y ros-$ROS_DISTRO-roslint
+            sudo apt-get install -y ros-$ROS_DISTRO-rospy
+            sudo apt-get install -y ros-$ROS_DISTRO-rospy-message-converter
+            sudo apt-get install -y ros-$ROS_DISTRO-rostest
+            sudo apt-get install -y ros-$ROS_DISTRO-sensor-msgs
+            sudo apt-get install -y ros-$ROS_DISTRO-std-msgs
+            sudo apt-get install -y ros-$ROS_DISTRO-tf
+            sudo apt-get install -y ros-$ROS_DISTRO-tf-conversions
+            sudo apt-get install -y ros-$ROS_DISTRO-tf2-geometry-msgs
+            sudo apt-get install -y ros-$ROS_DISTRO-tf2-msgs
+            sudo apt-get install -y ros-$ROS_DISTRO-tf2-py
+            sudo apt-get install -y ros-$ROS_DISTRO-tf2-ros
+            sudo apt-get install -y ros-$ROS_DISTRO-tf2-sensor-msgs
+      - name: build
+        run: |
+          source /opt/ros/$ROS_DISTRO/setup.bash
+          cargo build  # --verbose
+      - name: Install ROS packages for tests
+        run: |
+            sudo apt-get install -y ros-$ROS_DISTRO-actionlib-tutorials
+            sudo apt-get install -y ros-$ROS_DISTRO-roscpp-tutorials
+            sudo apt-get install -y ros-$ROS_DISTRO-rospy-tutorials
+      - name: test
+        run: |
+          source /opt/ros/$ROS_DISTRO/setup.bash
+          cargo test  # --verbose


### PR DESCRIPTION
I see there was an action from a year ago that wasn't working 7cf2d89bd0e3492e8c45ccb697fd3259b9520310 and then removed, but started from a known good action.

I could add builds for other ubuntu and ros versions if desired.

The action runs fine in my fork https://github.com/lucasw/rosrust/runs/1443591100, but not here as a part of the PR?  Maybe there is something different about the configuration of this repo that was generating the `Workflows can't be executed on this repository. Please check your payment method or billing status.` then and not running this now?