### PR TITLE
Replace deprecated net2 with socket2

### DIFF
--- a/rosrust/Cargo.toml
+++ b/rosrust/Cargo.toml
@@ -21,7 +21,7 @@ serde_derive = "1.0.102"
 xml-rpc = "0.0.12"
 yaml-rust = "0.4.3"
 crossbeam = "0.7.3"
-net2 = "0.2.33"
+socket2 = "0.4.0"
 colored = "1.8.0"
 
 [dev-dependencies]

--- a/rosrust/src/tcpros/client.rs
+++ b/rosrust/src/tcpros/client.rs
@@ -5,7 +5,7 @@ use crate::rosmsg::RosMsg;
 use byteorder::{LittleEndian, ReadBytesExt};
 use error_chain::bail;
 use log::error;
-use net2::TcpStreamExt;
+use socket2::Socket;
 use std;
 use std::collections::HashMap;
 use std::io;
@@ -55,7 +55,9 @@ fn connect_to_tcp_with_multiple_attempts(uri: &str, attempts: usize) -> io::Resu
     let mut repeat_delay_ms = 1;
     for _ in 0..attempts {
         let stream_result = TcpStream::connect(uri).and_then(|stream| {
-            stream.set_linger(None)?;
+            let socket: Socket = stream.into();
+            socket.set_linger(None)?;
+            let stream: TcpStream = socket.into();
             Ok(stream)
         });
         match stream_result {


### PR DESCRIPTION
Refs: https://rustsec.org/advisories/RUSTSEC-2020-0016

> The `net2` crate has been deprecated and users are encouraged to considered `socket2` instead.

