### PR TITLE
Hack to drop rosout publisher

### DIFF
--- a/rosrust/src/singleton.rs
+++ b/rosrust/src/singleton.rs
@@ -49,8 +49,11 @@ pub fn try_init_with_options(name: &str, capture_sigint: bool) -> Result<()> {
     let client = Ros::new(name)?;
     if capture_sigint {
         let shutdown_sender = client.shutdown_sender();
+        let logger = client.logger();
         ctrlc::set_handler(move || {
             shutdown_sender.shutdown();
+            // Drop rosout publisher
+            *logger.lock().unwrap() = None;
         })?;
     }
     *ros = Some(client);


### PR DESCRIPTION
I dug a little about #158.

When we use lazy_static! , `drop` is never called. Then the publisher of `/rosout` is not unregistered correctly, because it is also a member of the `Ros` instance not only Slave RAII control.
So, after a rosrust node is exited, the node is still registered as a publisher of `/rosout`.
This causes #158.

I don't know how to drop it more efficiently, but it seems that this change actually solves the issue.
If it is difficult to merge this change, I'm happy if @adnanademovic or somebody could resolve this issue.

The important thing is only dropping `/rosout` publisher!