### PR TITLE
panic if there are no message definitions during build.rs

### DIFF
--- a/rosrust_msg/build.rs
+++ b/rosrust_msg/build.rs
@@ -51,6 +51,12 @@ fn main() {
         .collect::<Vec<String>>()
         .join(",");
 
+    // Panic on an empty message list: there is no use for this, and it avoids
+    // a cryptic error in the proc macro invocation later on
+    if package_names.is_empty() {
+        panic!("empty package_names: are any of CMAKE_PREFIX_PATH and ROSRUST_MSG_PATH defined? is /opt/ros/<VERSION>/env sourced?");
+    }
+
     let file_content = format!(
         r#"
 rosrust::rosmsg_include!({},IGNORE_BAD);


### PR DESCRIPTION
Hi,

 This is an RFC. I've spent some time trying to understand failures in my CI when trying to build a simple project using rosrust. I finally realized the error, and I'm trying to make this error path clearer, by warning when forgetting to define CMAKE_PREFIX_PATH, usually by forgetting to source /opt/ros/melodic/[shell-setup] file. What do you think?

Alon

-----------

messages.rs contains definitions based on environment variables
defined by the ros setup.sh script. If that script is not invoked
and they are empty (or otherwise) then an error comes out later,
when messages.rs is built.

To avoid it, this commit causes an error during build time:

❯ CMAKE_PREFIX_PATH= cargo build
warning: /home/alon/other/rosrust/rosrust/Cargo.toml: file found to be present in multiple build targets: /home/alon/other/rosrust/rosrust/tests/benchmarks.rs
   Compiling rosrust_msg v0.1.4 (/home/alon/other/rosrust/rosrust_msg)
warning: use of deprecated associated function `std::array::IntoIter::<T, N>::new`: use `IntoIterator::into_iter` instead
   --> ros_message/src/value.rs:531:43
    |
531 |         Self::Array(std::array::IntoIter::new(v).map(Into::into).collect())
    |                                           ^^^
    |
    = note: `#[warn(deprecated)]` on by default

warning: `ros_message` (lib) generated 1 warning
error: failed to run custom build command for `rosrust_msg v0.1.4 (/home/alon/other/rosrust/rosrust_msg)`

Caused by:
  process didn't exit successfully: `/home/alon/other/rosrust/target/debug/build/rosrust_msg-3aaaa8688013c10a/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-env-changed=OUT_DIR
  cargo:rerun-if-env-changed=CMAKE_PREFIX_PATH
  cargo:rerun-if-env-changed=ROSRUST_MSG_PATH

  --- stderr
  thread 'main' panicked at 'empty package_names: are any of CMAKE_PREFIX_PATH and ROSRUST_MSG_PATH defined? is /opt/ros/<VERSION>/env sourced?', rosrust_msg/build.rs:57:9
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

The original error message is shorter but does not give a clue to the
underlying reason:

❯ CMAKE_PREFIX_PATH= cargo build
warning: /home/alon/other/rosrust/rosrust/Cargo.toml: file found to be present in multiple build targets: /home/alon/other/rosrust/rosrust/tests/benchmarks.rs
   Compiling rosrust_msg v0.1.4 (/home/alon/other/rosrust/rosrust_msg)
warning: use of deprecated associated function `std::array::IntoIter::<T, N>::new`: use `IntoIterator::into_iter` instead
   --> ros_message/src/value.rs:531:43
    |
531 |         Self::Array(std::array::IntoIter::new(v).map(Into::into).collect())
    |                                           ^^^
    |
    = note: `#[warn(deprecated)]` on by default

warning: `ros_message` (lib) generated 1 warning
error: proc macro panicked
 --> /home/alon/other/rosrust/target/debug/build/rosrust_msg-15aa38df61015bc6/out/messages.rs:2:1
  |
2 | rosrust::rosmsg_include!(,IGNORE_BAD);
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = help: message: Failed to parse all message paths