### PR TITLE
Add environment variable ROS_PACKAGE_PATH to paths searched for messages

### DIFF
--- a/rosrust_codegen/src/rosmsg_include.rs
+++ b/rosrust_codegen/src/rosmsg_include.rs
@@ -4,7 +4,6 @@ use quote::quote;
 use std::env;
 use std::path::Path;
 
-
 pub fn depend_on_messages(
     messages: &[&str],
     internal: bool,

--- a/rosrust_codegen/src/rosmsg_include.rs
+++ b/rosrust_codegen/src/rosmsg_include.rs
@@ -4,6 +4,7 @@ use quote::quote;
 use std::env;
 use std::path::Path;
 
+
 pub fn depend_on_messages(
     messages: &[&str],
     internal: bool,
@@ -19,6 +20,11 @@ pub fn depend_on_messages(
         .split(':')
         .filter_map(append_src_folder)
         .collect::<Vec<String>>();
+    let ros_package_paths = env::var("ROS_PACKAGE_PATH")
+        .unwrap_or_default()
+        .split(':')
+        .map(String::from)
+        .collect::<Vec<String>>();
     let extra_paths = env::var("ROSRUST_MSG_PATH")
         .unwrap_or_default()
         .split(':')
@@ -27,6 +33,7 @@ pub fn depend_on_messages(
     let paths = cmake_paths
         .iter()
         .chain(cmake_alt_paths.iter())
+        .chain(ros_package_paths.iter())
         .chain(extra_paths.iter())
         .map(String::as_str)
         .collect::<Vec<&str>>();

--- a/rosrust_msg/build.rs
+++ b/rosrust_msg/build.rs
@@ -7,6 +7,7 @@ fn main() {
 
     rerun_if_env_changed("OUT_DIR");
     rerun_if_env_changed("CMAKE_PREFIX_PATH");
+    rerun_if_env_changed("ROS_PACKAGE_PATH");
     rerun_if_env_changed("ROSRUST_MSG_PATH");
 
     let cmake_paths = env::var("CMAKE_PREFIX_PATH")
@@ -19,6 +20,11 @@ fn main() {
         .split(':')
         .filter_map(append_src_folder)
         .collect::<Vec<String>>();
+    let ros_package_paths = env::var("ROS_PACKAGE_PATH")
+        .unwrap_or_default()
+        .split(':')
+        .map(String::from)
+        .collect::<Vec<String>>();
     let extra_paths = env::var("ROSRUST_MSG_PATH")
         .unwrap_or_default()
         .split(':')
@@ -27,6 +33,7 @@ fn main() {
     let paths = cmake_paths
         .iter()
         .chain(cmake_alt_paths.iter())
+        .chain(ros_package_paths.iter())
         .chain(extra_paths.iter())
         .collect::<Vec<_>>();
     for path in &paths {


### PR DESCRIPTION
This PR adds the ROS_PACKAGE_PATH as a source for paths where messages will be searched for. This is the variable used by tools like [rospack](https://github.com/ros/rospack/blob/ad85a874575bbed74124b722b42b545537cc6aa3/src/rospack.cpp#L284) which are in turn used by `rosmsg` and `rossrv` for finding packages on the system.

I noticed that this block of code is duplicated in a couple places and I think it makes sense to try to de-duplicate it, but I'll leave that to another issue/merge request.

This seeks to close issue #166  