### PR TITLE
Add more conversions between Time/Duration and `std` types, and add `Time::now()`.

### DIFF
--- a/ros_message/src/tests/time.rs
+++ b/ros_message/src/tests/time.rs
@@ -37,7 +37,7 @@ fn duration_works_with_negative() {
 }
 
 #[test]
-fn convert_works() {
+fn duration_from_std_works() {
     let std_duration = time::Duration::new(123, 456);
     let msg_duration = Duration::from(std_duration);
     assert_eq!(msg_duration.sec, 123);
@@ -47,6 +47,19 @@ fn convert_works() {
     let msg_duration2: Duration = std_duration2.into();
     assert_eq!(msg_duration2.sec, 9876);
     assert_eq!(msg_duration2.nsec, 54321);
+}
+
+#[test]
+fn duration_to_std_works() {
+    let msg_duration = Duration { sec: 123, nsec: 456 };
+    let std_duration = time::Duration::from(msg_duration);
+    assert_eq!(std_duration.as_secs(), 123);
+    assert_eq!(std_duration.subsec_nanos(), 456);
+
+    let msg_duration2 = Duration { sec: 9876, nsec: 54321 };
+    let std_duration2: time::Duration = msg_duration2.into();
+    assert_eq!(std_duration2.as_secs(), 9876);
+    assert_eq!(std_duration2.subsec_nanos(), 54321);
 }
 
 #[test]

--- a/ros_message/src/tests/time.rs
+++ b/ros_message/src/tests/time.rs
@@ -63,6 +63,32 @@ fn duration_to_std_works() {
 }
 
 #[test]
+fn time_from_std_works() {
+    let std_time = time::SystemTime::UNIX_EPOCH + time::Duration::new(123, 456);
+    let msg_time = Time::from(std_time);
+    assert_eq!(msg_time.sec, 123);
+    assert_eq!(msg_time.nsec, 456);
+
+    let std_time2 = time::SystemTime::UNIX_EPOCH + time::Duration::new(9876, 54321);
+    let msg_time2: Time = std_time2.into();
+    assert_eq!(msg_time2.sec, 9876);
+    assert_eq!(msg_time2.nsec, 54321);
+}
+
+#[test]
+fn time_to_std_works() {
+    let msg_time = Time { sec: 123, nsec: 456 };
+    let std_time = time::SystemTime::from(msg_time);
+    assert_eq!((std_time.duration_since(time::SystemTime::UNIX_EPOCH)).unwrap().as_secs(), 123);
+    assert_eq!((std_time.duration_since(time::SystemTime::UNIX_EPOCH)).unwrap().subsec_nanos(), 456);
+
+    let msg_time2 = Time { sec: 9876, nsec: 54321 };
+    let std_time2: time::SystemTime = msg_time2.into();
+    assert_eq!((std_time2.duration_since(time::SystemTime::UNIX_EPOCH)).unwrap().as_secs(), 9876);
+    assert_eq!((std_time2.duration_since(time::SystemTime::UNIX_EPOCH)).unwrap().subsec_nanos(), 54321);
+}
+
+#[test]
 fn display_zero() {
     let time = Time::from_nanos(0);
     assert_eq!(format!("{}", time), "0");

--- a/ros_message/src/time.rs
+++ b/ros_message/src/time.rs
@@ -38,28 +38,6 @@ impl Time {
         Self::default()
     }
 
-    /// Get the current time.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use ros_message::Time;
-    /// # #[derive(Default)]
-    /// # struct Header {
-    /// #   stamp: Time,
-    /// # }
-    /// # #[derive(Default)]
-    /// # struct Message {
-    /// #   header: Header,
-    /// # }
-    /// # let mut message = Message::default();
-    /// message.header.stamp = Time::now();
-    /// ```
-    #[inline]
-    pub fn now() -> Self {
-        time::SystemTime::now().into()
-    }
-
     /// Creates a time of the given number of nanoseconds.
     ///
     /// # Examples

--- a/ros_message/src/time.rs
+++ b/ros_message/src/time.rs
@@ -134,6 +134,25 @@ impl cmp::Ord for Time {
     }
 }
 
+impl From<time::SystemTime> for Time {
+    fn from(other: time::SystemTime) -> Self {
+        let epoch = time::SystemTime::UNIX_EPOCH;
+        let elapsed = other.duration_since(epoch).unwrap();
+        Self {
+            sec: elapsed.as_secs().try_into().unwrap(),
+            nsec: elapsed.subsec_nanos(),
+        }
+    }
+}
+
+impl From<Time> for time::SystemTime {
+    fn from(other: Time) -> Self {
+        let elapsed = time::Duration::new(other.sec.into(), other.nsec);
+        time::SystemTime::UNIX_EPOCH + elapsed
+
+    }
+}
+
 /// ROS representation of duration, with nanosecond precision
 #[derive(Copy, Clone, Default, Serialize, Deserialize, Debug, Eq)]
 pub struct Duration {

--- a/ros_message/src/time.rs
+++ b/ros_message/src/time.rs
@@ -38,6 +38,28 @@ impl Time {
         Self::default()
     }
 
+    /// Get the current time.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use ros_message::Time;
+    /// # #[derive(Default)]
+    /// # struct Header {
+    /// #   stamp: Time,
+    /// # }
+    /// # #[derive(Default)]
+    /// # struct Message {
+    /// #   header: Header,
+    /// # }
+    /// # let mut message = Message::default();
+    /// message.header.stamp = Time::now();
+    /// ```
+    #[inline]
+    pub fn now() -> Self {
+        time::SystemTime::now().into()
+    }
+
     /// Creates a time of the given number of nanoseconds.
     ///
     /// # Examples

--- a/rosrust/src/lib.rs
+++ b/rosrust/src/lib.rs
@@ -11,6 +11,7 @@ pub use dynamic_msg::DynamicMsg;
 pub use ros_message::{Duration, MessageValue as MsgMessage, Time, Value as MsgValue};
 #[doc(hidden)]
 pub use rosrust_codegen::*;
+pub mod wall_time;
 
 pub mod api;
 mod dynamic_msg;

--- a/rosrust/src/wall_time.rs
+++ b/rosrust/src/wall_time.rs
@@ -1,0 +1,30 @@
+//! Utilities for time information based on the system clock.
+
+/// Get the current time from the system clock.
+///
+/// This is esentially the same as:
+/// ```
+/// # let time: rosrust::Time =
+/// std::time::SystemTime::now().into()
+/// # ;
+/// ```
+///
+/// # Examples
+///
+/// ```
+/// # use ros_message::Time;
+/// # #[derive(Default)]
+/// # struct Header {
+/// #   stamp: Time,
+/// # }
+/// # #[derive(Default)]
+/// # struct Message {
+/// #   header: Header,
+/// # }
+/// # let mut message = Message::default();
+/// message.header.stamp = rosrust::wall_time::now();
+/// ```
+#[inline]
+pub fn now() -> crate::Time {
+    std::time::SystemTime::now().into()
+}


### PR DESCRIPTION
This PR implements conversion from `Duration` to `std::time::Duration`, conversions between `Time` and `std::time::SystemTime`, and adds `Time::now()` to get the current time.

It also adds unit tests for the new conversions.