### PR TITLE
Read the ROSCONSOLE_FORMAT env var to format the logs

### DIFF
--- a/rosrust/Cargo.toml
+++ b/rosrust/Cargo.toml
@@ -23,6 +23,7 @@ yaml-rust = "0.4.5"
 crossbeam = "0.8.1"
 socket2 = "0.4.1"
 colored = "2.0.0"
+thread-id = "4.0.0"
 
 [dependencies.ros_message]
 path = "../ros_message"


### PR DESCRIPTION
This is a naive approach, not much optimized because each call to `String::replace()` will allocate a new `String`, a bit like the [`rospy` implementation](https://github.com/ros/ros_comm/blob/f5fa3a168760d62e9693f10dcb9adfffc6132d22/tools/rosgraph/src/rosgraph/roslogging.py#L247-L287).

I did not implement the tokens for which the value were not already available. This can be done later.

The new `thread-id` dependency should not bring too much new dependencies as it only requires `libc` on Linux for example.

I have added a space to `INFO` and `WARN` level strings so all levels have the same string length.
I did this to mimic [rosconsole](https://github.com/ros/rosconsole/blob/1.14.3/src/rosconsole/rosconsole.cpp#L161-L165).
But I have just noticed that on the `noetic-devel` branch, not yet released, the spaces are gone thanks to this PR https://github.com/ros/rosconsole/pull/52
I personally prefer the space so the logs are well aligned.

To implement several loggers, we would need a more advanced logging system. Did you try to use the existing rust `log` ecosystem and create a `rosrust` backend for it?