### PR TITLE
Keep trailing zeros when displaying Time and Duration

### DIFF
--- a/ros_message/src/tests/time.rs
+++ b/ros_message/src/tests/time.rs
@@ -52,9 +52,9 @@ fn convert_works() {
 #[test]
 fn display_zero() {
     let time = Time::from_nanos(0);
-    assert_eq!(format!("{}", time), "0");
+    assert_eq!(format!("{}", time), "0.000000000");
     let time = Duration::from_nanos(0);
-    assert_eq!(format!("{}", time), "0");
+    assert_eq!(format!("{}", time), "0.000000000");
 }
 
 #[test]
@@ -72,29 +72,29 @@ fn display_trailing_zeros() {
     let time = Time::from_nanos(123456789987654321);
     assert_eq!(format!("{}", time), "123456789.987654321");
     let time = Time::from_nanos(123456789987654000);
-    assert_eq!(format!("{}", time), "123456789.987654");
+    assert_eq!(format!("{}", time), "123456789.987654000");
     let time = Time::from_nanos(123456789000000000);
-    assert_eq!(format!("{}", time), "123456789");
+    assert_eq!(format!("{}", time), "123456789.000000000");
     let time = Time::from_nanos(123456700000000000);
-    assert_eq!(format!("{}", time), "123456700");
+    assert_eq!(format!("{}", time), "123456700.000000000");
 
     let time = Duration::from_nanos(-123456789987654321);
     assert_eq!(format!("{}", time), "-123456789.987654321");
     let time = Duration::from_nanos(-123456789987654000);
-    assert_eq!(format!("{}", time), "-123456789.987654");
+    assert_eq!(format!("{}", time), "-123456789.987654000");
     let time = Duration::from_nanos(-123456789000000000);
-    assert_eq!(format!("{}", time), "-123456789");
+    assert_eq!(format!("{}", time), "-123456789.000000000");
     let time = Duration::from_nanos(-123456700000000000);
-    assert_eq!(format!("{}", time), "-123456700");
+    assert_eq!(format!("{}", time), "-123456700.000000000");
 
     let time = Duration::from_nanos(-123456789987654321);
     assert_eq!(format!("{}", time), "-123456789.987654321");
     let time = Duration::from_nanos(-123456789987654000);
-    assert_eq!(format!("{}", time), "-123456789.987654");
+    assert_eq!(format!("{}", time), "-123456789.987654000");
     let time = Duration::from_nanos(-123456789000000000);
-    assert_eq!(format!("{}", time), "-123456789");
+    assert_eq!(format!("{}", time), "-123456789.000000000");
     let time = Duration::from_nanos(-123456700000000000);
-    assert_eq!(format!("{}", time), "-123456700");
+    assert_eq!(format!("{}", time), "-123456700.000000000");
 }
 
 #[test]
@@ -106,11 +106,11 @@ fn display_decimals() {
     let time = Time::from_nanos(654321);
     assert_eq!(format!("{}", time), "0.000654321");
     let time = Time::from_nanos(9987654000);
-    assert_eq!(format!("{}", time), "9.987654");
+    assert_eq!(format!("{}", time), "9.987654000");
     let time = Time::from_nanos(987654000);
-    assert_eq!(format!("{}", time), "0.987654");
+    assert_eq!(format!("{}", time), "0.987654000");
     let time = Time::from_nanos(654000);
-    assert_eq!(format!("{}", time), "0.000654");
+    assert_eq!(format!("{}", time), "0.000654000");
 
     let time = Duration::from_nanos(-9987654321);
     assert_eq!(format!("{}", time), "-9.987654321");
@@ -119,11 +119,11 @@ fn display_decimals() {
     let time = Duration::from_nanos(-654321);
     assert_eq!(format!("{}", time), "-0.000654321");
     let time = Duration::from_nanos(-9987654000);
-    assert_eq!(format!("{}", time), "-9.987654");
+    assert_eq!(format!("{}", time), "-9.987654000");
     let time = Duration::from_nanos(-987654000);
-    assert_eq!(format!("{}", time), "-0.987654");
+    assert_eq!(format!("{}", time), "-0.987654000");
     let time = Duration::from_nanos(-654000);
-    assert_eq!(format!("{}", time), "-0.000654");
+    assert_eq!(format!("{}", time), "-0.000654000");
 
     let time = Duration::from_nanos(-9987654321);
     assert_eq!(format!("{}", time), "-9.987654321");
@@ -132,9 +132,14 @@ fn display_decimals() {
     let time = Duration::from_nanos(-654321);
     assert_eq!(format!("{}", time), "-0.000654321");
     let time = Duration::from_nanos(-9987654000);
-    assert_eq!(format!("{}", time), "-9.987654");
+    assert_eq!(format!("{}", time), "-9.987654000");
     let time = Duration::from_nanos(-987654000);
-    assert_eq!(format!("{}", time), "-0.987654");
+    assert_eq!(format!("{}", time), "-0.987654000");
     let time = Duration::from_nanos(-654000);
-    assert_eq!(format!("{}", time), "-0.000654");
+    assert_eq!(format!("{}", time), "-0.000654000");
+
+    let time = Duration{sec: -1, nsec: 1};
+    assert_eq!(format!("{}", time), "-0.999999999");
+    let time = Duration{sec: -1, nsec: -1};
+    assert_eq!(format!("{}", time), "-1.000000001");
 }

--- a/ros_message/src/tests/value.rs
+++ b/ros_message/src/tests/value.rs
@@ -55,7 +55,7 @@ fn display() {
 header: 
   frame_id: "abc"
   seq: 22
-  stamp: 123.1
+  stamp: 123.100000000
 poses: 
   - 
     orientation: 

--- a/ros_message/src/time.rs
+++ b/ros_message/src/time.rs
@@ -98,15 +98,12 @@ impl Time {
 }
 
 fn display_nanos(nanos: &str, f: &mut Formatter<'_>) -> fmt::Result {
+    // Special display function to handle edge cases like
+    // Duration { sec: -1, nsec: 1 } and Duration { sec: -1, nsec: -1 }
     let split_point = nanos.len() - 9;
     let characters = nanos.chars();
     let (left, right) = characters.as_str().split_at(split_point);
-    let right = right.trim_end_matches('0');
-    if right.is_empty() {
-        write!(f, "{}", left)
-    } else {
-        write!(f, "{}.{}", left, right)
-    }
+    write!(f, "{}.{}", left, right)
 }
 
 impl fmt::Display for Time {


### PR DESCRIPTION
Allow to have nicely aligned logs, like in roscpp