### PR TITLE
Clean up node on shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - `wall_time::now` for easier retrieval of actual time when running recordings
 - Convenience conversions between ROS time structures and standard time structures
 - `wait_for_subscribers` in publisher
+### Fixed
+- Clean up node on shutdown (by either using `spin()`, `shutdown()`, or `is_ok()` until it's false)
 
 ### Fixed
 - Fix deeply nested relative field paths in dynamic messages

--- a/rosrust/src/api/mod.rs
+++ b/rosrust/src/api/mod.rs
@@ -5,32 +5,33 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 mod clock;
 pub mod error;
+pub mod handlers;
 mod master;
 mod naming;
 pub mod raii;
 pub mod resolve;
 mod ros;
 mod slave;
-pub mod handlers;
 
 pub struct ShutdownManager {
+    handler: Box<dyn Fn() + Send + Sync>,
     should_shutdown: AtomicBool,
 }
 
-impl Default for ShutdownManager {
-    fn default() -> Self {
+impl ShutdownManager {
+    pub fn new(handler: impl Fn() + Send + Sync + 'static) -> Self {
         Self {
+            handler: Box::new(handler),
             should_shutdown: AtomicBool::new(false),
         }
     }
-}
 
-impl ShutdownManager {
     pub fn awaiting_shutdown(&self) -> bool {
         self.should_shutdown.load(Ordering::Relaxed)
     }
 
     pub fn shutdown(&self) {
+        (*self.handler)();
         self.should_shutdown.store(true, Ordering::Relaxed)
     }
 }


### PR DESCRIPTION
The internal `/rosout` topic was staying on through a shutdown. To initiate this cleanup now, a call to shutdown is required. That is guaranteed if you use `.is_ok()` or `.spin()` to keep the app running. If using neither, `rosrust::shutdown()` is a necessary call at the end.

Fixes #125
Fixes #158
Closes #160