### PR TITLE
Add caching for rosparam get requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Rosrust Unreleased
+### Added
+- Automatic caching of parameters
+
 ## Rosrust Msg 0.1.7 (2023-04-01)
 ### Added
 - Find messages in `ROS_PACKAGE_PATH`

--- a/rosrust/examples/publish_from_param.rs
+++ b/rosrust/examples/publish_from_param.rs
@@ -1,0 +1,47 @@
+use std::time::Instant;
+
+mod msg {
+    rosrust::rosmsg_include!(std_msgs / String);
+}
+
+fn main() {
+    env_logger::init();
+
+    // Initialize node
+    rosrust::init("talker");
+
+    // Create publisher
+    let chatter_pub = rosrust::publish("chatter", 2).unwrap();
+    chatter_pub.wait_for_subscribers(None).unwrap();
+
+    let message = rosrust::param("~message").unwrap();
+
+    let log_names = rosrust::param("~log_names").unwrap().get().unwrap_or(false);
+
+    // Create object that maintains 10Hz between sleep requests
+    let rate = rosrust::rate(10.0);
+
+    // Breaks when a shutdown signal is sent
+    while rosrust::is_ok() {
+        let t = Instant::now();
+        let message = message.get::<String>().unwrap_or_else(|_| "-".to_string());
+        let message_fetch_time = t.elapsed();
+        // Create string message
+        let msg = msg::std_msgs::String {
+            data: format!("{} from rosrust in {:?}", message, message_fetch_time),
+        };
+
+        // Log event
+        rosrust::ros_info!("Publishing: {}", msg.data);
+
+        // Send string message to topic via publisher
+        chatter_pub.send(msg).unwrap();
+
+        if log_names {
+            rosrust::ros_info!("Subscriber names: {:?}", chatter_pub.subscriber_names());
+        }
+
+        // Sleep to maintain 10Hz rate
+        rate.sleep();
+    }
+}

--- a/rosrust/examples/publish_from_param.rs
+++ b/rosrust/examples/publish_from_param.rs
@@ -24,11 +24,11 @@ fn main() {
     // Breaks when a shutdown signal is sent
     while rosrust::is_ok() {
         let t = Instant::now();
-        let message = message.get::<String>().unwrap_or_else(|_| "-".to_string());
+        let message = message.get_raw().unwrap_or(xml_rpc::Value::Bool(false));
         let message_fetch_time = t.elapsed();
         // Create string message
         let msg = msg::std_msgs::String {
-            data: format!("{} from rosrust in {:?}", message, message_fetch_time),
+            data: format!("{:?} from rosrust in {:?}", message, message_fetch_time),
         };
 
         // Log event

--- a/rosrust/src/api/ros.rs
+++ b/rosrust/src/api/ros.rs
@@ -113,12 +113,14 @@ impl Ros {
             move || drop(logger.lock().unwrap().take())
         }));
 
+        let param_cache = Arc::new(Mutex::new(HashMap::new()));
         let slave = Slave::new(
             master_uri,
             hostname,
             bind_host,
             0,
             &name,
+            Arc::clone(&param_cache),
             Arc::clone(&shutdown_manager),
         )?;
         let master = Master::new(master_uri, &name, slave.uri())?;
@@ -126,7 +128,7 @@ impl Ros {
         Ok(Ros {
             master: Arc::new(master),
             slave: Arc::new(slave),
-            param_cache: Arc::new(Mutex::new(HashMap::new())),
+            param_cache,
             hostname: String::from(hostname),
             bind_address: String::from(bind_host),
             resolver,

--- a/rosrust/src/api/ros.rs
+++ b/rosrust/src/api/ros.rs
@@ -507,7 +507,7 @@ impl Parameter {
     }
 
     pub fn get_raw(&self) -> Response<xml_rpc::Value> {
-        let mut subscribed = false;
+        let subscribed;
         {
             let cache = self.param_cache.lock().expect(FAILED_TO_LOCK);
             if let Some(data) = cache.data.get(&self.name) {

--- a/rosrust/src/api/slave/handler.rs
+++ b/rosrust/src/api/slave/handler.rs
@@ -127,7 +127,7 @@ impl SlaveHandler {
                     ))
                 }
             };
-            let parameter_value = match args.next() {
+            let _parameter_value = match args.next() {
                 Some(parameter_value) => parameter_value,
                 _ => {
                     return Err(ResponseError::Client(

--- a/rosrust/src/api/slave/mod.rs
+++ b/rosrust/src/api/slave/mod.rs
@@ -2,10 +2,10 @@ mod handler;
 mod publications;
 mod subscriptions;
 
+pub use self::handler::ParamCache;
 use self::handler::SlaveHandler;
 use super::error::{self, ErrorKind, Result};
 use crate::api::ShutdownManager;
-use crate::rosxmlrpc::Response;
 use crate::tcpros::{Message, PublisherStream, Service, ServicePair, ServiceResult};
 use crate::util::{kill, FAILED_TO_LOCK};
 use crate::{RawMessageDescription, SubscriptionHandler};
@@ -34,7 +34,7 @@ impl Slave {
         bind_address: &str,
         port: u16,
         name: &str,
-        param_cache: Arc<Mutex<HashMap<String, Response<xml_rpc::Value>>>>,
+        param_cache: ParamCache,
         shutdown_manager: Arc<ShutdownManager>,
     ) -> Result<Slave> {
         use std::net::ToSocketAddrs;

--- a/rosrust/src/api/slave/mod.rs
+++ b/rosrust/src/api/slave/mod.rs
@@ -5,6 +5,7 @@ mod subscriptions;
 use self::handler::SlaveHandler;
 use super::error::{self, ErrorKind, Result};
 use crate::api::ShutdownManager;
+use crate::rosxmlrpc::Response;
 use crate::tcpros::{Message, PublisherStream, Service, ServicePair, ServiceResult};
 use crate::util::{kill, FAILED_TO_LOCK};
 use crate::{RawMessageDescription, SubscriptionHandler};
@@ -33,12 +34,14 @@ impl Slave {
         bind_address: &str,
         port: u16,
         name: &str,
+        param_cache: Arc<Mutex<HashMap<String, Response<xml_rpc::Value>>>>,
         shutdown_manager: Arc<ShutdownManager>,
     ) -> Result<Slave> {
         use std::net::ToSocketAddrs;
 
         let (shutdown_tx, shutdown_rx) = kill::channel(kill::KillMode::Sync);
-        let handler = SlaveHandler::new(master_uri, hostname, name, shutdown_tx.clone());
+        let handler =
+            SlaveHandler::new(master_uri, hostname, name, param_cache, shutdown_tx.clone());
         let publications = handler.publications.clone();
         let subscriptions = handler.subscriptions.clone();
         let services = Arc::clone(&handler.services);

--- a/rosrust/src/rosxmlrpc/client.rs
+++ b/rosrust/src/rosxmlrpc/client.rs
@@ -63,6 +63,6 @@ fn bad_request_structure<T: ::std::fmt::Display>(err: T) -> ResponseError {
     ResponseError::Client(format!("Failed to serialize parameters: {}", err))
 }
 
-fn bad_response_structure<T: ::std::fmt::Display>(err: T) -> ResponseError {
+pub(crate) fn bad_response_structure<T: ::std::fmt::Display>(err: T) -> ResponseError {
     ResponseError::Server(format!("Response data has unexpected structure: {}", err))
 }

--- a/rosrust/src/rosxmlrpc/mod.rs
+++ b/rosrust/src/rosxmlrpc/mod.rs
@@ -9,7 +9,7 @@ pub mod server;
 
 pub type Response<T> = Result<T, ResponseError>;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum ResponseError {
     Client(String),
     Server(String),


### PR DESCRIPTION
Addresses some concerns of #183 , as it implements the most common way of using