### PR TITLE
chore: replace deprecated error_chain with this error in codegen

### DIFF
--- a/rosrust_codegen/Cargo.toml
+++ b/rosrust_codegen/Cargo.toml
@@ -9,13 +9,13 @@ repository = "https://github.com/adnanademovic/rosrust"
 version = "0.9.6"
 
 [dependencies]
-error-chain = "0.12.4"
 lazy_static = "1.4.0"
 quote = "1.0.9"
 syn = "1.0.74"
 proc-macro2 = "1.0.28"
 md-5 = "0.9.1"
 hex = "0.4.3"
+thiserror = "1.0.40"
 
 [dependencies.ros_message]
 path = "../ros_message"

--- a/rosrust_codegen/src/error.rs
+++ b/rosrust_codegen/src/error.rs
@@ -1,12 +1,28 @@
-error_chain::error_chain! {
-    errors {
-        MessageNotFound(msg: String, folders: String) {
-            description("message not found in provided directories")
-            display("message {} not found in provided directories\nDirectories:\n{}", msg, folders)
-        }
-        PackageNameInvalid(package: String) {
-            description("referenced package does not have a valid name. Look at ROS REP 144 for more details.")
-            display("package '{}' does not have a valid name. Look at ROS REP 144 for more details.", package)
-        }
-    }
+use std::io;
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    /// Message not found in provided directories.
+    #[error("message {msg} not found in provided directories\nDirectories:\n{folders}")]
+    MessageNotFound { msg: String, folders: String },
+    /// Message map does not contain all needed elements.
+    #[error("message map does not contain all needed elements")]
+    MessageMapIncomplete,
+    /// Failed to read file to string.
+    #[error("failed to read file to string")]
+    ReadFile(#[source] io::Error),
+    /// Failed to build service messages.
+    #[error("failed to build service messages")]
+    BuildMessage(#[source] ros_message::Error),
+    /// Failed to parse all message paths.
+    #[error("failed to parse all message paths")]
+    ParseMessagePaths(#[source] ros_message::Error),
+    /// Invalid message path.
+    #[error("invalid message path")]
+    MessagePath(#[source] ros_message::Error),
+    /// Failed to parse message.
+    #[error("failed to parse message")]
+    ParseMessage(#[source] ros_message::Error),
 }

--- a/rosrust_codegen/src/msg.rs
+++ b/rosrust_codegen/src/msg.rs
@@ -1,4 +1,4 @@
-use crate::error::{Result, ResultExt};
+use crate::error::{Error, Result};
 use lazy_static::lazy_static;
 use proc_macro2::{Literal, Span};
 use quote::{quote, ToTokens};
@@ -19,7 +19,7 @@ impl Msg {
     pub fn new(path: MessagePath, source: &str) -> Result<Msg> {
         ros_message::Msg::new(path, source)
             .map(Self)
-            .chain_err(|| "Failed to parse message")
+            .map_err(Error::ParseMessage)
     }
 
     pub fn name_ident(&self) -> Ident {


### PR DESCRIPTION
As this was the smaller crate I used it as a POC for thiserror use. (as this is
not really a library and more of a bin crate being a procmacro, it could also be
considered to use something line [anyhow](https://docs.rs/anyhow), or the
proc-macro specific [manyhow](https://docs.rs/manyhow).
