### PR TITLE
Fix over-eager rebuilding of rosrust_msg when nothing changed

### DIFF
--- a/rosrust_msg/Cargo.toml
+++ b/rosrust_msg/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 name = "rosrust_msg"
 readme = "../README.md"
 repository = "https://github.com/adnanademovic/rosrust"
-version = "0.1.7"
+version = "0.1.8"
 build = "build.rs"
 
 [dependencies]

--- a/rosrust_msg/build.rs
+++ b/rosrust_msg/build.rs
@@ -94,9 +94,7 @@ pub fn rerun_if_folder_content_changed(folder: &Path) {
         }
         return;
     }
-    if let Some(name) = folder.to_str() {
-        rerun_if_file_changed(name);
-    }
+
     if let Ok(children) = fs::read_dir(folder) {
         for child in children.filter_map(Result::ok) {
             rerun_if_folder_content_changed(&child.path());


### PR DESCRIPTION
Fixes https://github.com/adnanademovic/rosrust/issues/176, where all files including inside .git are tracked by build.rs and triggers rebuilds too often.