### PR TITLE
Reduce shutdown poll time to greatly reduce CPU usage

### DIFF
--- a/rosrust/src/api/slave/mod.rs
+++ b/rosrust/src/api/slave/mod.rs
@@ -65,7 +65,7 @@ impl Slave {
                 }
                 bound_handler.poll();
                 // TODO: use a timed out poll once rouille provides it
-                std::thread::sleep(std::time::Duration::from_millis(5));
+                std::thread::sleep(std::time::Duration::from_secs(1));
             }
             shutdown_manager.shutdown();
         });


### PR DESCRIPTION
5ms shutdown polling adds a great amount of CPU overhead, especially with multiple nodes running. Reducing to once per second has little noticeable effect on shutdown but with huge decrease in CPU usage.